### PR TITLE
Made frozenset.__repr__ output in literal format

### DIFF
--- a/Lib/pprint.py
+++ b/Lib/pprint.py
@@ -271,7 +271,25 @@ class PrettyPrinter:
         stream.write(endchar)
 
     _dispatch[set.__repr__] = _pprint_set
-    _dispatch[frozenset.__repr__] = _pprint_set
+
+    def _pprint_frozenset(self, object, stream, indent, allowance, context, level):
+        if not len(object):
+            stream.write(repr(object))
+            return
+        typ = object.__class__
+        if typ is frozenset:
+            stream.write('{{')
+            endchar = '}}'
+        else:
+            stream.write(typ.__name__ + '({')
+            endchar = '})'
+            indent += len(typ.__name__)
+        object = sorted(object, key=_safe_key)
+        self._format_items(object, stream, indent + 1, allowance + len(endchar),
+                           context, level)
+        stream.write(endchar)
+
+    _dispatch[frozenset.__repr__] = _pprint_frozenset
 
     def _pprint_str(self, object, stream, indent, allowance, context, level):
         write = stream.write

--- a/Lib/test/test_frozensetcomps.py
+++ b/Lib/test/test_frozensetcomps.py
@@ -13,7 +13,7 @@ Test simple loop with conditional
 Test simple case
 
     >>> {{2*y + x + 1 for x in (0,) for y in (1,)}}
-    frozenset({3})
+    {{3}}
 
 Test simple nesting
 
@@ -88,7 +88,7 @@ Generators can call other generators:
 Make sure that None is a valid return value
 
     >>> {{None for i in range(10)}}
-    frozenset({None})
+    {{None}}
 
 ########### Tests for various scoping corner cases ############
 
@@ -102,21 +102,21 @@ Same again, only this time as a closure variable
 
     >>> items = {{(lambda: i) for i in range(5)}}
     >>> {{x() for x in items}}
-    frozenset({4})
+    {{4}}
 
 Another way to test that the iteration variable is local to the frozenset comp
 
     >>> items = {{(lambda: i) for i in range(5)}}
     >>> i = 20
     >>> {{x() for x in items}}
-    frozenset({4})
+    {{4}}
 
 And confirm that a closure can jump over the frozenset comp scope
 
     >>> items = {{(lambda: y) for i in range(5)}}
     >>> y = 2
     >>> {{x() for x in items}}
-    frozenset({2})
+    {{2}}
 
 We also repeat each of the above scoping tests inside a function
 
@@ -130,21 +130,21 @@ We also repeat each of the above scoping tests inside a function
     ...     items = {{(lambda: i) for i in range(5)}}
     ...     return {{x() for x in items}}
     >>> test_func()
-    frozenset({4})
+    {{4}}
 
     >>> def test_func():
     ...     items = {{(lambda: i) for i in range(5)}}
     ...     i = 20
     ...     return {{x() for x in items}}
     >>> test_func()
-    frozenset({4})
+    {{4}}
 
     >>> def test_func():
     ...     items = {{(lambda: y) for i in range(5)}}
     ...     y = 2
     ...     return {{x() for x in items}}
     >>> test_func()
-    frozenset({2})
+    {{2}}
 
 """
 

--- a/Lib/test/test_fstring.py
+++ b/Lib/test/test_fstring.py
@@ -684,7 +684,7 @@ x = (
         # Inside of strings, don't interpret doubled brackets.
         self.assertEqual(f'{"{{}}"}', '{{}}')
 
-        self.assertEqual(f'{ {{10}} }', 'frozenset({10})')
+        self.assertEqual(f'{ {{10}} }', '{{10}}')
         self.assertAllRaise(SyntaxError,
                             "f-string: expecting a valid expression after '{'",
                             ["f'{ {{}} }'", # invalid syntax

--- a/Lib/test/test_pprint.py
+++ b/Lib/test/test_pprint.py
@@ -602,15 +602,15 @@ set2({0,
 
         self.assertEqual(pprint.pformat(frozenset()), 'frozenset()')
         self.assertEqual(pprint.pformat(frozenset(range(3))),
-                         'frozenset({0, 1, 2})')
+                         '{{0, 1, 2}}')
         self.assertEqual(pprint.pformat(frozenset(range(7)), width=20), '''\
-frozenset({0,
-           1,
-           2,
-           3,
-           4,
-           5,
-           6})''')
+{{0,
+  1,
+  2,
+  3,
+  4,
+  5,
+  6}}''')
         self.assertEqual(pprint.pformat(frozenset2(range(7)), width=20), '''\
 frozenset2({0,
             1,
@@ -652,13 +652,13 @@ frozenset2({0,
         fs1 = frozenset(('abc', 'xyz'))
         data = frozenset((fs0, fs1))
         self.assertEqual(pprint.pformat(data),
-                         'frozenset({%r, %r})' % (fs0, fs1))
+                         '{{%r, %r}}' % (fs0, fs1))
         self.assertEqual(pprint.pformat(data), repr(data))
 
         fs2 = frozenset(('one', 'two'))
         data = {fs2: frozenset((fs0, fs1))}
         self.assertEqual(pprint.pformat(data),
-                         "{%r: frozenset({%r, %r})}" % (fs2, fs0, fs1))
+                         "{%r: {{%r, %r}}}" % (fs2, fs0, fs1))
         self.assertEqual(pprint.pformat(data), repr(data))
 
         # Single-line, unordered:
@@ -675,15 +675,15 @@ frozenset2({0,
         fs1 = frozenset(('regular string', 'other string'))
         fs2 = frozenset(('third string', 'one more string'))
         check(
-            pprint.pformat(frozenset((fs1, fs2))),
+            pprint.pformat({{fs1, fs2}}, width=60),
             [
                 """
-                frozenset({%r,
-                           %r})
+                {{%r,
+                  %r}}
                 """ % (fs1, fs2),
                 """
-                frozenset({%r,
-                           %r})
+                {{%r,
+                  %r}}
                 """ % (fs2, fs1),
             ],
         )
@@ -691,44 +691,45 @@ frozenset2({0,
         # Everything is multiline, unordered:
         check(
             pprint.pformat(
-                frozenset((
-                    frozenset((
+                {{
+                    {{
                         "xyz very-very long string",
                         "qwerty is also absurdly long",
-                    )),
-                    frozenset((
+                    }},
+                    {{
                         "abcd is even longer that before",
                         "spam is not so long",
-                    )),
-                )),
+                    }},
+                }},
+                width=40
             ),
             [
                 """
-                frozenset({frozenset({'abcd is even longer that before',
-                                      'spam is not so long'}),
-                           frozenset({'qwerty is also absurdly long',
-                                      'xyz very-very long string'})})
+                {{{{'abcd is even longer that before',
+                    'spam is not so long'}},
+                  {{'qwerty is also absurdly long',
+                    'xyz very-very long string'}}}}
                 """,
 
                 """
-                frozenset({frozenset({'abcd is even longer that before',
-                                      'spam is not so long'}),
-                           frozenset({'xyz very-very long string',
-                                      'qwerty is also absurdly long'})})
+                {{{{'abcd is even longer that before',
+                    'spam is not so long'}},
+                  {{'xyz very-very long string',
+                    'qwerty is also absurdly long'}}}}
                 """,
 
                 """
-                frozenset({frozenset({'qwerty is also absurdly long',
-                                      'xyz very-very long string'}),
-                           frozenset({'abcd is even longer that before',
-                                      'spam is not so long'})})
+                {{{{'qwerty is also absurdly long',
+                    'xyz very-very long string'}},
+                  {{'abcd is even longer that before',
+                    'spam is not so long'}}}}
                 """,
 
                 """
-                frozenset({frozenset({'qwerty is also absurdly long',
-                                      'xyz very-very long string'}),
-                           frozenset({'spam is not so long',
-                                      'abcd is even longer that before'})})
+                {{{{'qwerty is also absurdly long',
+                    'xyz very-very long string'}},
+                {{{{'spam is not so long',
+                    'abcd is even longer that before'}}}}
                 """,
             ],
         )
@@ -759,7 +760,7 @@ frozenset2({0,
         self.assertEqual(clean(pprint.pformat(set(keys))),
             '{' + ','.join(map(repr, skeys)) + '}')
         self.assertEqual(clean(pprint.pformat(frozenset(keys))),
-            'frozenset({' + ','.join(map(repr, skeys)) + '})')
+            '{{' + ','.join(map(repr, skeys)) + '}}')
         self.assertEqual(clean(pprint.pformat(dict.fromkeys(keys))),
             '{' + ','.join('%r:None' % k for k in skeys) + '}')
 

--- a/Lib/test/test_set.py
+++ b/Lib/test/test_set.py
@@ -317,6 +317,8 @@ class TestJointOps:
         w.value = s
         if self.thetype == set:
             self.assertEqual(repr(s), '{set(...)}')
+        elif self.thetype == frozenset:
+            self.assertEqual(repr(s), '{{frozenset(...)}}')
         else:
             name = repr(s).partition('(')[0]    # strip class name
             self.assertEqual(repr(s), '%s({%s(...)})' % (name, name))

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -558,12 +558,14 @@ set_repr_lock_held(PySetObject *so)
         goto done;
     listrepr = tmp;
 
-    if (!PySet_CheckExact(so))
-        result = PyUnicode_FromFormat("%s({%U})",
-                                      Py_TYPE(so)->tp_name,
-                                      listrepr);
-    else
+    if (PySet_CheckExact(so))
         result = PyUnicode_FromFormat("{%U}", listrepr);
+    else if (PyFrozenSet_CheckExact(so))
+        result = PyUnicode_FromFormat("{{%U}}", listrepr);
+    else
+        result = PyUnicode_FromFormat("%s({%U})",
+              Py_TYPE(so)->tp_name,
+              listrepr);
     Py_DECREF(listrepr);
 done:
     Py_ReprLeave((PyObject*)so);

--- a/Objects/setobject.c
+++ b/Objects/setobject.c
@@ -564,8 +564,8 @@ set_repr_lock_held(PySetObject *so)
         result = PyUnicode_FromFormat("{{%U}}", listrepr);
     else
         result = PyUnicode_FromFormat("%s({%U})",
-              Py_TYPE(so)->tp_name,
-              listrepr);
+                                      Py_TYPE(so)->tp_name,
+                                      listrepr);
     Py_DECREF(listrepr);
 done:
     Py_ReprLeave((PyObject*)so);


### PR DESCRIPTION
@nineteendo I was able to make `frozenset.__repr__` output in literal format with minimal changes. Seems to work well. Let me know if you find anything wrong.